### PR TITLE
Fix issues with `RocksDatabase` when spawning new tokio thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,8 +925,9 @@ dependencies = [
 
 [[package]]
 name = "nostr"
-version = "0.28.1"
-source = "git+https://github.com/rust-nostr/nostr.git?branch=master#89253a9c3845478cabd1bb69f6f9d2f26ec79876"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "255485c2f41cf8f39d4e4a1901199549f54e32def81a71a8afe05f75809f441d"
 dependencies = [
  "aes",
  "base64",
@@ -953,31 +954,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nostr"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "255485c2f41cf8f39d4e4a1901199549f54e32def81a71a8afe05f75809f441d"
-dependencies = [
- "base64",
- "bip39",
- "bitcoin",
- "cbc",
- "chacha20",
- "chacha20poly1305",
- "getrandom",
- "instant",
- "negentropy",
- "once_cell",
- "scrypt",
- "serde",
- "serde_json",
- "tracing",
- "unicode-normalization",
- "url",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "nostr-database"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,7 +962,7 @@ dependencies = [
  "async-trait",
  "flatbuffers",
  "lru",
- "nostr 0.29.0",
+ "nostr",
  "thiserror",
  "tokio",
  "tracing",
@@ -1000,7 +976,7 @@ checksum = "7349d04b433163edd15bb6f5aa3fc7398e2953a5e133b2e1b22f884147204038"
 dependencies = [
  "async-trait",
  "jobserver",
- "nostr 0.29.0",
+ "nostr",
  "nostr-database",
  "num_cpus",
  "rocksdb",
@@ -1301,7 +1277,7 @@ dependencies = [
  "env_logger",
  "futures-util",
  "log",
- "nostr 0.28.1",
+ "nostr",
  "nostr-database",
  "nostr-rocksdb",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1.77"
-tokio = { version = "1", features = ["full"] }
-nostr = { git = "https://github.com/rust-nostr/nostr.git", branch = "master" }
-tokio-tungstenite = "0.21.0"
+env_logger = "0.11.3"
 futures-util = "0.3.30"
 log = "0.4.21"
-env_logger = "0.11.3"
+nostr = "0.29.0"
 nostr-rocksdb = "0.29.0"
 nostr-database = "0.29.0"
 serde_json = "1"
+tokio = { version = "1", features = ["full"] }
+tokio-tungstenite = "0.21.0"

--- a/src/db.rs
+++ b/src/db.rs
@@ -14,31 +14,31 @@ use nostr::{
 
 pub enum Error {
     Event(nostr::event::Error),
-    MessageHandleError(MessageHandleError),
-    MsgapiError(msgapi::Error),
-    DatabaseError(DatabaseError),
+    MessageHandle(MessageHandleError),
+    Msgapi(msgapi::Error),
+    Database(DatabaseError),
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Error::Event(e) => write!(f, "event: {}", e),
-            Error::MessageHandleError(e) => write!(f, "message handle error: {}", e),
-            Error::MsgapiError(e) => write!(f, "msgapi error: {}", e),
-            Error::DatabaseError(e) => write!(f, "database error: {}", e),
+            Error::MessageHandle(e) => write!(f, "message handle error: {}", e),
+            Error::Msgapi(e) => write!(f, "msgapi error: {}", e),
+            Error::Database(e) => write!(f, "database error: {}", e),
         }
     }
 }
 
 impl From<DatabaseError> for Error {
     fn from(e: DatabaseError) -> Self {
-        Self::DatabaseError(e)
+        Self::Database(e)
     }
 }
 
 impl From<msgapi::Error> for Error {
     fn from(e: msgapi::Error) -> Self {
-        Self::MsgapiError(e)
+        Self::Msgapi(e)
     }
 }
 
@@ -50,7 +50,7 @@ impl From<nostr::event::Error> for Error {
 
 impl From<MessageHandleError> for Error {
     fn from(e: MessageHandleError) -> Self {
-        Self::MessageHandleError(e)
+        Self::MessageHandle(e)
     }
 }
 
@@ -61,7 +61,7 @@ pub struct Server {
 impl Server {
     pub async fn new() -> Result<Self, Error> {
         let db = RocksDatabase::open("./db/rocksdb").await?;
-        Ok(Server { db: Mutex::new(db) })
+        Ok(Self { db: Mutex::new(db) })
     }
 }
 #[async_trait]

--- a/src/msgapi/incoming.rs
+++ b/src/msgapi/incoming.rs
@@ -8,7 +8,7 @@ use nostr_database::nostr;
 use nostr_database::{DatabaseError, NostrDatabase, Order};
 use nostr_rocksdb::RocksDatabase;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct IncomingMessage {
     db: RocksDatabase,
 }
@@ -75,7 +75,7 @@ impl MessageHandler for IncomingMessage {
         let ret = <ClientMessage as nostr::JsonUtil>::from_json(txt)?;
         Ok(ret)
     }
-    async fn handlers(&self, ClientMessage: ClientMessage) -> Result<Vec<String>, Error> {
+async fn handlers(&self, ClientMessage: ClientMessage) -> Result<Vec<String>, Error> {
         match ClientMessage {
             ClientMessage::Event(event) => {
                 let eid = event.id();

--- a/src/msgapi/incoming.rs
+++ b/src/msgapi/incoming.rs
@@ -16,8 +16,8 @@ pub struct IncomingMessage {
 #[derive(Debug)]
 pub enum Error {
     Event(event::Error),
-    MessageHandleError(MessageHandleError),
-    DatabaseError(nostr_rocksdb::database::DatabaseError),
+    MessageHandle(MessageHandleError),
+    Database(nostr_rocksdb::database::DatabaseError),
     ToClientMessage(serde_json::Error),
 }
 
@@ -25,8 +25,8 @@ impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Self::Event(e) => write!(f, "event: {}", e),
-            Self::MessageHandleError(e) => write!(f, "message handle error: {}", e),
-            Self::DatabaseError(e) => write!(f, "database error: {}", e),
+            Self::MessageHandle(e) => write!(f, "message handle error: {}", e),
+            Self::Database(e) => write!(f, "database error: {}", e),
             Self::ToClientMessage(e) => write!(f, "to client message error: {}", e),
         }
     }
@@ -46,26 +46,26 @@ impl From<serde_json::Error> for Error {
 
 impl From<nostr_rocksdb::database::DatabaseError> for Error {
     fn from(e: nostr_rocksdb::database::DatabaseError) -> Self {
-        Self::DatabaseError(e)
+        Self::Database(e)
     }
 }
 
 impl From<MessageHandleError> for Error {
     fn from(e: MessageHandleError) -> Self {
-        Self::MessageHandleError(e)
+        Self::MessageHandle(e)
     }
 }
 
 impl IncomingMessage {
     pub async fn new() -> Result<Self, Error> {
         let db = RocksDatabase::open("./db/rocksdb").await?;
-        Ok(IncomingMessage { db })
+        Ok(Self { db })
     }
 }
 
 #[async_trait]
 pub trait MessageHandler {
-    async fn handlers(&self, ClientMessage: ClientMessage) -> Result<Vec<String>, Error>;
+    async fn handlers(&self, client_message: ClientMessage) -> Result<Vec<String>, Error>;
     async fn to_client_message(&self, txt: &str) -> Result<ClientMessage, Error>;
 }
 
@@ -75,8 +75,8 @@ impl MessageHandler for IncomingMessage {
         let ret = <ClientMessage as nostr::JsonUtil>::from_json(txt)?;
         Ok(ret)
     }
-async fn handlers(&self, ClientMessage: ClientMessage) -> Result<Vec<String>, Error> {
-        match ClientMessage {
+    async fn handlers(&self, client_message: ClientMessage) -> Result<Vec<String>, Error> {
+        match client_message {
             ClientMessage::Event(event) => {
                 let eid = event.id();
                 let event_existed = self.db.has_event_already_been_saved(&eid).await?;
@@ -109,17 +109,12 @@ async fn handlers(&self, ClientMessage: ClientMessage) -> Result<Vec<String>, Er
                 let ret = vec!["TODO".to_string()];
                 Ok(ret)
             }
-            ClientMessage::Req {
-                subscription_id,
-                filters,
-            } => {
+            ClientMessage::Req { filters, .. } => {
                 let order = Order::Desc;
                 let queried_events = self.db.query(filters, order).await?;
-                let mut ret = vec![];
-                for event in &queried_events {
-                    let raw = Event::as_json(&event);
-                    let event_json: serde_json::Value = serde_json::from_str(&raw)?;
-                    let response = serde_json::json!(["EVENT", "test", event_json]);
+                let mut ret = Vec::with_capacity(queried_events.len());
+                for event in queried_events.into_iter() {
+                    let response = serde_json::json!(["EVENT", "test", event]);
                     ret.push(response.to_string());
                 }
                 Ok(ret)

--- a/src/web.rs
+++ b/src/web.rs
@@ -27,25 +27,25 @@ use tokio_tungstenite::tungstenite::protocol::Message;
 
 pub enum Error {
     Event(nostr::event::Error),
-    MessageHandleError(MessageHandleError),
-    DatabaseError(DatabaseError),
-    TcpListenerError(std::io::Error),
+    MessageHandle(MessageHandleError),
+    Database(DatabaseError),
+    TcpListener(std::io::Error),
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Error::Event(e) => write!(f, "event: {}", e),
-            Error::MessageHandleError(e) => write!(f, "message handle error: {}", e),
-            Error::DatabaseError(e) => write!(f, "database error: {}", e),
-            Error::TcpListenerError(e) => write!(f, "tcp listener error: {}", e),
+            Error::MessageHandle(e) => write!(f, "message handle error: {}", e),
+            Error::Database(e) => write!(f, "database error: {}", e),
+            Error::TcpListener(e) => write!(f, "tcp listener error: {}", e),
         }
     }
 }
 
 impl From<std::io::Error> for Error {
     fn from(e: std::io::Error) -> Self {
-        Self::TcpListenerError(e)
+        Self::TcpListener(e)
     }
 }
 
@@ -57,13 +57,13 @@ impl From<nostr::event::Error> for Error {
 
 impl From<MessageHandleError> for Error {
     fn from(e: MessageHandleError) -> Self {
-        Self::MessageHandleError(e)
+        Self::MessageHandle(e)
     }
 }
 
 impl From<DatabaseError> for Error {
     fn from(e: DatabaseError) -> Self {
-        Self::DatabaseError(e)
+        Self::Database(e)
     }
 }
 
@@ -100,13 +100,12 @@ impl WebServer {
     }
 
     pub async fn run(&self) {
-        let _listener = match self.start_listening().await {
+        match self.start_listening().await {
             Ok(l) => {
                 self.accept_connection(l).await;
             }
             Err(e) => {
                 log::error!("Failed to start listening: {}", e);
-                return;
             }
         };
     }


### PR DESCRIPTION
Hey, I fixed the issue related to the `tokio::spawn` and `RocksDatabase` in the da56e392db731021cafc251f3b421e5289d069dd commit

In the others, I done some clippy lints and cleanup (ex. use same version of `nostr` for all `rust-nostr` crates to avoid double compilation, use `Vec::with_capacity` instead of `vec![]` to increase the performance, ...).

So, the fix is in the first commit, feel free to discard the others if you not agree withe those changes.